### PR TITLE
fix: add word-break and remove min-width

### DIFF
--- a/src/styles/table.css
+++ b/src/styles/table.css
@@ -1,6 +1,5 @@
 table {
   background-color: #fff;
-  min-width: 650px;
   display: table;
   border: solid 1px #e5e5e5;
   border-collapse: collapse;
@@ -13,4 +12,5 @@ table th {
 th,
 td {
   padding: 16px;
+  word-break : break-all;
 }


### PR DESCRIPTION
#### サマリー
スマホでスケジュールを見ると横スクロールが発生したので修正しました。

#### Before

![Screen Shot 2021-07-14 at 14 16 59](https://user-images.githubusercontent.com/1716463/125565471-2f927863-c6f5-4854-842c-d7a32eecbf6d.png)

#### After

![Screen Shot 2021-07-14 at 14 16 47](https://user-images.githubusercontent.com/1716463/125565475-66e3f2ce-1cec-49ce-bf16-dc3aa59b3ddf.png)
