### PR TITLE
GitHub ActionsでLighthouseを実行してアクセサビリティをチェックするようにした

### DIFF
--- a/.github/workflows/LIGHTHOUSE.yml
+++ b/.github/workflows/LIGHTHOUSE.yml
@@ -1,0 +1,32 @@
+name: LIGHTHOUSE
+
+on:
+  push:
+    branches:
+      - lighthouse # for operation verification. remove this before merge into develop
+  pull_request:
+    branches:
+      - develop
+      - lighthouse # for operation verification. remove this before merge into develop
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+      - name: npm install
+        run: npm ci
+      - name: Build App
+        run: npm run build
+      - name: Run Lighthouse against a static dist dir
+        uses: treosh/lighthouse-ci-action@v7
+        with:
+          configPath: ./lighthouse.js
+          uploadArtifacts: true
+          temporaryPublicStorage: true
+        env:
+          LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}

--- a/.github/workflows/LIGHTHOUSE.yml
+++ b/.github/workflows/LIGHTHOUSE.yml
@@ -1,13 +1,9 @@
 name: LIGHTHOUSE
 
 on:
-  push:
-    branches:
-      - lighthouse # for operation verification. remove this before merge into develop
   pull_request:
     branches:
       - develop
-      - lighthouse # for operation verification. remove this before merge into develop
 
 jobs:
   lighthouse:

--- a/.github/workflows/LIGHTHOUSE.yml
+++ b/.github/workflows/LIGHTHOUSE.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Run Lighthouse against a static dist dir
         uses: treosh/lighthouse-ci-action@v7
         with:
-          configPath: ./lighthouse.js
+          configPath: ./.lighthouse.js
           uploadArtifacts: true
           temporaryPublicStorage: true
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ public
 src/contents/external/*
 !src/contents/external/.gitkeep
 !src/contents/external/mapping.json
+
+.lighthouseci/

--- a/.lighthouse.js
+++ b/.lighthouse.js
@@ -6,7 +6,7 @@ module.exports = {
     },
     assert: {
       assertions: {
-        "categories:accessibility": ["error", {minScore: 1}]
+        "categories:accessibility": ["error", {minScore: 0.9}]
       }
     },
   },

--- a/.lighthouse.js
+++ b/.lighthouse.js
@@ -4,5 +4,10 @@ module.exports = {
       // collect options here
       staticDistDir: "./public"
     },
+    assert: {
+      assertions: {
+        "categories:accessibility": ["error", {minScore: 0.9}]
+      }
+    },
   },
 };

--- a/.lighthouse.js
+++ b/.lighthouse.js
@@ -1,0 +1,8 @@
+module.exports = {
+  ci: {
+    collect: {
+      // collect options here
+      staticDistDir: "./public"
+    },
+  },
+};

--- a/.lighthouse.js
+++ b/.lighthouse.js
@@ -6,7 +6,7 @@ module.exports = {
     },
     assert: {
       assertions: {
-        "categories:accessibility": ["error", {minScore: 0.9}]
+        "categories:accessibility": ["error", {minScore: 1}]
       }
     },
   },


### PR DESCRIPTION
Fix #21 

[treosh/lighthouse-ci-action](https://github.com/treosh/lighthouse-ci-action) を利用してLighthouse CIをGitHub Actionsで実行するようにしました。
アサーションは`accessibility`カテゴリーのみを対象にしています。

### 確認したこと
- [x] GitHub ActionでLighthouse CIを実行してアクセサビリティをチェックすること。
- [x] `lighthouse`ブランチに対してRPを作成してGitHub ActionでLighthouse CIが実行されること。
- [x] スコアが悪い(最低スコアを超えない)とチェックがfailedになること。
- [x] スコアが悪ければマージ不可になる、スコアが良ければマージ可能になる

### 気になっていること
- マージ不可になるスコアの調整は必要か？。尚、マージ不可になる(GitHub Status Checkでfailedになる)のはLighthouseのチェック結果がwarningではなくerrorになった場合なので、調整時はwarnではなくerrorの閾値を調整する必要がありそう。https://github.com/GoogleChrome/lighthouse-ci/blob/31e731a338ee50d241ea9ae40400748bd3901c4b/packages/cli/src/upload/upload.js#L252 辺りのコードから判断。