### PR TITLE
fix: update top page

### DIFF
--- a/src/contents/index.md
+++ b/src/contents/index.md
@@ -4,8 +4,24 @@ slug: "/"
 
 # Amplify Japan User Group
 
-<コミュニティ紹介>
+## コミュニティ紹介
 
-<コミュニティの目的>
+Amplify 日本ユーザーグループ (Amplify Japan User Group) は、 AWS Amplify の利用者・開発者が主体となり、
+相互に AWS Amplify の利用・開発をサポートするために、主に日本国内で活動するグループです。
 
-<運営メンバー>
+
+## コミュニティの目的
+
+本コミュニティは AWS Amplify について、主に日本国内の利用者および(または)日本語によって、情報交換する目的で運営するものです。
+AWS Amplify の利用方法、実運用含めた開発時の知見や課題、周辺技術との連携に関する疑問、といったことがざっくばらんにやりとりされています。
+
+また、定期的にミートアップを開催し、より多くの人に情報を伝える活動も行っています。
+
+## 運営メンバー
+
+* Daijiro Wachi ([twitter](https://twitter.com/watilde))
+* Jaga ([twitter](https://twitter.com/jagaimogmog))
+* Kento Ikeda ([twitter](https://twitter.com/ikenyal))
+* Masahiko Murakami ([twitter](https://twitter.com/fossamagna))
+* tacck ([twitter](https://twitter.com/tacck))
+* Yoshiaki Togami ([twitter](https://twitter.com/togami2864))


### PR DESCRIPTION
トップページのコンテンツ更新。

運営メンバーについては、ミートアップ名 (Amplify Boost Up) の投票を行なった時点のメンバーをリストアップ。

Fixes: https://github.com/aws-amplify-jp/aws-amplify-jp.github.io/issues/8