### PR TITLE
chore: Update lighthouse-ci-actions to v8

### DIFF
--- a/.github/workflows/TEST.yml
+++ b/.github/workflows/TEST.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Build App
         run: npm run build
       - name: Run Lighthouse against to a static dist dir
-        uses: treosh/lighthouse-ci-action@v7
+        uses: treosh/lighthouse-ci-action@v8
         with:
           configPath: ./.lighthouse.js
           uploadArtifacts: true


### PR DESCRIPTION
[Lighthouse v0.8.0](https://github.com/GoogleChrome/lighthouse-ci/releases/tag/v0.8.0)を利用する[treosh/lighthouse-ci-actions](https://github.com/marketplace/actions/lighthouse-ci-action?version=v8)の新しいバージョンがリリースされたのでバージョンアップしました。