### PR TITLE
chore: update users-in-japan.js

### DIFF
--- a/src/contents/contributors/users-in-japan.js
+++ b/src/contents/contributors/users-in-japan.js
@@ -1,7 +1,9 @@
 [
   "jaga810",
   "yana-katty",
+  "hirofumi",
   "h-kishi",
   "kooooohe",
+  "yosuke-matsuda",
   "yuuu"
 ]


### PR DESCRIPTION
https://github.com/aws-amplify-jp/aws-amplify-contributors/pull/7/commits/f728aa5b988fe21a050ed88e66f0764681e17c09 で追加になるuserでlocationから日本と判断できないが日本の方のお二人を追加した。