### PR TITLE
実行委員に青木 光平を追加

### DIFF
--- a/static/conference/2026/index.html
+++ b/static/conference/2026/index.html
@@ -452,6 +452,22 @@
               </div>
             </a>
           </article>
+          <article class="organizer-card">
+            <a class="organizer-card__link" href="https://x.com/coa00" target="_blank" rel="noopener">
+              <figure class="organizer-card__avatar">
+                <img src="https://github.com/coa00.png" alt="青木 光平" loading="lazy">
+              </figure>
+              <div class="organizer-card__info">
+                <h3>青木 光平</h3>
+                <div class="social-link">
+                  <svg class="x-icon" viewBox="0 0 24 24" width="16" height="16">
+                    <path fill="currentColor" d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
+                  </svg>
+                  @coa00
+                </div>
+              </div>
+            </a>
+          </article>
         </div>
       </div>
     </section>


### PR DESCRIPTION
PR #108を参考に、実行委員セクションに青木 光平さんを追加しました。

## 変更内容
- `static/conference/2026/index.html` に青木 光平さんの実行委員カードを追加
- Xアカウント: @coa00 (https://x.com/coa00)
- 画像: GitHubアバターを使用

## 参考
- PR #108: 木原 卓也さんの追加方法を参考にしました